### PR TITLE
fix: add missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ python-dotenv>=1.0.0
 pydantic>=2.0.0
 mcp>=0.1.0
 pyarrow>=14.0.1
-requests>=2.31.0 
+requests>=2.31.0
+packaging>=24.2


### PR DESCRIPTION
`packaging` is missing as a dependency during my installation.